### PR TITLE
Correct metric name for current connections/items

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ const (
 var (
 	cacheOperations  = []string{"get", "delete", "incr", "decr", "cas", "touch"}
 	cacheStatuses    = []string{"hits", "misses"}
-	usageTimes       = []string{"current", "total"}
+	usageTimes       = []string{"curr", "total"}
 	usageResources   = []string{"items", "connections"}
 	bytesDirections  = []string{"read", "written"}
 	removalsStatuses = []string{"expired", "evicted"}


### PR DESCRIPTION
Trying to fetch the metrics `current_items` and `current_connections` returns 0. Should be `curr_items` and `curr_connections`.

```
ivar@server:~$ echo stats | nc 127.0.0.1 11211 | grep "\(items\|connections\)"
STAT curr_connections 921
STAT total_connections 42623
STAT curr_items 51234
STAT total_items 634466
```
