### PR TITLE
Adding the ability to monitor multiple memcache instances

### DIFF
--- a/main.go
+++ b/main.go
@@ -198,11 +198,11 @@ func main() {
 		metricsPath   = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
 	)
 	flag.Parse()
-  servers := strings.Split(flag.Arg(0),",")
-  for _, server := range servers {
-  	exporter := NewExporter(server)
-	  prometheus.MustRegister(exporter)
-  }
+        servers := strings.Split(flag.Arg(0),",")
+        for _, server := range servers {
+                exporter := NewExporter(server)
+                prometheus.MustRegister(exporter)
+        }
 
 	http.Handle(*metricsPath, prometheus.Handler())
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+  "strings"
 	"sync"
 
 	"github.com/Snapbug/gomemcache/memcache"
@@ -197,10 +198,11 @@ func main() {
 		metricsPath   = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
 	)
 	flag.Parse()
-
-	exporter := NewExporter(flag.Arg(0))
-
-	prometheus.MustRegister(exporter)
+  servers := strings.Split(flag.Arg(0),",")
+  for _, server := range servers {
+  	exporter := NewExporter(server)
+	  prometheus.MustRegister(exporter)
+  }
 
 	http.Handle(*metricsPath, prometheus.Handler())
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
In our case just because we have multiple instances of memcache on the same server and it does not make sense to execute multiple exporters - that's the only reason for the change.
I guess that it can also be used for other cases where people might want to monitor multiple memcache servers without installing exporters on each - edge case I guess.
